### PR TITLE
Add script to configure fluentd with elasticsearch

### DIFF
--- a/fluentd-operator/README.md
+++ b/fluentd-operator/README.md
@@ -14,7 +14,7 @@ Logging operator uses fluent-bit and fluentd for collection and processing of lo
 **Output** is a Custom Resource Definition that defines a datastore where logs are to be stored. Currently, the operator supports ElasticSearch, S3 and Loki as log stores.
 
 ## Logging on PMK Cluster ###
-If you are using a PMK provisioned cluster, fluentd-operator can be automatically enabled on the cluster by adding appropriate tags in the UI.
+If you are using a PMK provisioned cluster, fluentd-operator can be automatically enabled on the cluster by adding `pf9-system:logging` tag in the UI during cluster creation.
 
 For deploying elasticsearch datastore, configuring with fluentd-operator and viewing the logs in Kibana, you can simply run the below script
 
@@ -23,6 +23,10 @@ For deploying elasticsearch datastore, configuring with fluentd-operator and vie
 ```
 
 This script deploys ECK (Elastic Cloud on Kubernetes) along with elasticsearch and kibana deployments. It also creates the `Output` Custom Resource pointing to the elasticsearch deployment and automatically forwarding logs to Kibana.
+
+**Note:** Make sure to set the below mentioned variables prior to running the script
+
+` $DU_FQDN | $DU_USERNAME | $DU_PASSWORD | $DU_CLUSTER `
 
 Finally you can check the index (defined in Output CR) getting created in elasticsearch and can view the logs in Kibana.
 

--- a/fluentd-operator/README.md
+++ b/fluentd-operator/README.md
@@ -1,0 +1,56 @@
+# fluentd-operator
+
+### Log pipeline management for Kubernetes ###
+Logging operator provides Kubernetes native log management for developers and devops teams. Main benefits are:
+
+* Configure logging using Kubernetes constructs. No need to learn log configurations.
+* Flexibility and Reuse through Kubernetes Custom Resource Definitions.
+* Handles logging service deployment and scaling.
+* Support for popular datastores like ElasticSearch, S3 and Loki.
+
+### Understanding ###
+Logging operator uses fluent-bit and fluentd for collection and processing of logs respectively. The fluent-bit component is deployed as daemonset that performs log formatting and filtering. Fluentd is used as aggregator and buffer which ships logs to chosen datastore. 
+
+**Output** is a Custom Resource Definition that defines a datastore where logs are to be stored. Currently, the operator supports ElasticSearch, S3 and Loki as log stores.
+
+## Logging on PMK Cluster ###
+If you are using a PMK provisioned cluster, fluentd-operator can be automatically enabled on the cluster by adding appropriate tags in the UI.
+
+For deploying elasticsearch datastore, configuring with fluentd-operator and viewing the logs in Kibana, you can simply run the below script
+
+```
+./configure-fluentd-es.sh 
+```
+
+This script deploys ECK (Elastic Cloud on Kubernetes) along with elasticsearch and kibana deployments. It also creates the `Output` Custom Resource pointing to the elasticsearch deployment and automatically forwarding logs to Kibana.
+
+Finally you can check the index (defined in Output CR) getting created in elasticsearch and can view the logs in Kibana.
+
+
+### Installing Operator (manually) ###
+If operator is not already installed, you can install and configure it with with the script provided in fluentd-operator repository
+```
+github.com/platform9/fluentd-operator/hack/deploy.sh
+```
+
+#### Configure datastore ####
+The below example shows how to forward logs to an object storage like elasticsearch.
+
+Create output CR indicating elasticsearch as destination. Note that elasticsearch should be deployed in the same cluster.
+```yaml
+apiVersion: logging.pf9.io/v1alpha1
+kind: Output
+metadata:
+  name: objstore
+spec:
+  type: elasticsearch
+  params:
+    - name: url
+      value: <ELASTIC_SERVICE_FQDN>
+    - name: user
+      value: <ELASTIC_USERNAME>
+    - name: password
+      value: <ELASTIC_PASSWORD>
+    - name: index_name
+      value: <INDEX_NAME_IN_ELASTIC>
+```

--- a/fluentd-operator/configure-fluentd-es.sh
+++ b/fluentd-operator/configure-fluentd-es.sh
@@ -1,0 +1,72 @@
+RCol='\e[0m'    # Text Reset
+Blu='\e[0;34m'
+Gre='\e[0;32m'
+Yel='\e[0;33m'
+BBla='\e[1;30m'
+URed='\e[4;31m'
+On_Whi='\e[47m'
+
+FLUENTD_OPERATOR_DEPLOYMENTS_PATH="$PWD/deployments"
+FLUENTD_NAMESPACE="logging"
+
+ELASTIC_USER="elastic"
+ELASTIC_APP="app-elasticsearch"
+ELASTIC_SVC="${ELASTIC_APP}-es-http"
+
+function deploy_elastic_stack() {
+  echo -e "\n[${Blu}ACTION${RCol}] Deploying elasticsearch operator and creating CRDs...\n"
+  kubectl apply -f 'https://download.elastic.co/downloads/eck/1.1.2/all-in-one.yaml'
+  echo -e "\n[${Gre}RESULT${RCol}] Successfully deployed elasticsearch operator"
+  
+  echo -e "\n[${Blu}ACTION${RCol}] Create a storage class and setting it to default\n"
+  kubectl apply -f "https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml"
+  kubectl patch storageclass standard -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+  kubectl patch storageclass local-path -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+  echo -e "\n[${Gre}RESULT${RCol}] Created storage class for elasticsearch"
+
+  echo -e "\n[${Blu}ACTION${RCol}] Deploying elasticsearch application\n"
+  kubectl apply -f $FLUENTD_OPERATOR_DEPLOYMENTS_PATH/elasticsearch.yaml
+  echo -e "\n[${Blu}ACTION${RCol}] Deploying kibana application\n"
+  kubectl apply -f $FLUENTD_OPERATOR_DEPLOYMENTS_PATH/kibana.yaml
+}
+
+function wait_for_deployments() {
+  echo -e "\n[${Blu}ACTION${RCol}] Waiting for elasticsearch to come up..."
+  es_status="$(kubectl get elasticsearch app-elasticsearch --namespace=$FLUENTD_NAMESPACE -o=jsonpath='{.status.health}' 2> /dev/null)"
+  until [[ "$es_status" == "green" ]] || [[ "$es_status" == "yellow" ]]; do printf '.'; sleep 5; es_status="$(kubectl get elasticsearch app-elasticsearch --namespace=$FLUENTD_NAMESPACE -o=jsonpath='{.status.health}' 2> /dev/null)"; done; echo
+  echo -e "[${Gre}RESULT${RCol}] Elasticsearch application is up and running!!"
+  echo -e "\n[${Blu}ACTION${RCol}] Waiting for kibana to come up..."
+  kb_status=$(kubectl get kibana app-kibana --namespace=$FLUENTD_NAMESPACE -o=jsonpath='{.status.health}' 2> /dev/null)
+  until [[ "$kb_status" == "green" ]] || [[ "$kb_status" == "yellow" ]]; do printf '.'; sleep 5; kb_status=$(kubectl get kibana app-kibana --namespace=$FLUENTD_NAMESPACE -o=jsonpath='{.status.health}' 2> /dev/null); done; echo
+  echo -e "[${Gre}RESULT${RCol}] Kibana application is up and running!!"
+  echo -e "\n[${Gre}RESULT${RCol}] All resources are up and running. Moving forward..."
+}
+
+function connect_fluentd_es() {
+  echo -e "\n[${Blu}ACTION${RCol}] Connecting fluentd with elasticsearch\n"
+  
+  ELASTIC_PASS=$(kubectl get secret app-elasticsearch-es-elastic-user --namespace=$FLUENTD_NAMESPACE -o go-template='{{.data.elastic | base64decode}}')
+  sed "s/%CHANGE_SVC%/$ELASTIC_SVC/; s/%CHANGE_NAMESPACE%/$FLUENTD_NAMESPACE/; s/%CHANGE_USER%/$ELASTIC_USER/ ;s/%CHANGE_PASS%/$ELASTIC_PASS/" ${FLUENTD_OPERATOR_DEPLOYMENTS_PATH}/cr-fluentd-elastic-example.yaml > ${FLUENTD_OPERATOR_DEPLOYMENTS_PATH}/cr-fluentd-elastic.yaml
+  
+  kubectl apply -f $FLUENTD_OPERATOR_DEPLOYMENTS_PATH/cr-fluentd-elastic.yaml
+  FLUENTD_POD=$(kubectl get pod --namespace=$FLUENTD_NAMESPACE -l 'k8s-app=fluentd' -o=jsonpath='{.items[0].metadata.name}')
+  kubectl delete pod --namespace=$FLUENTD_NAMESPACE $FLUENTD_POD > /dev/null
+
+  echo -e "\n[${Gre}RESULT${RCol}] Successfully established connection between fluentd and elasticsearch!!"
+}
+
+function export_kibana() {
+  echo -e "\n*****************************************************************"
+  echo "You can now login into kibana using below credentials"
+  echo -e "\n${Gre}USERNAME:${RCol} $ELASTIC_USER"
+  echo -e "${Gre}PASSWORD:${RCol} $ELASTIC_PASS"
+  echo -e "\n*****************************************************************"
+  kubectl port-forward service/app-kibana-kb-http --namespace=$FLUENTD_NAMESPACE 5601 > /dev/null
+}
+
+deploy_elastic_stack
+wait_for_deployments
+connect_fluentd_es
+export_kibana
+
+trap "{ rm -rf ${FLUENTD_OPERATOR_DEPLOYMENTS_PATH}/cr-fluentd-elastic.yaml; }" EXIT INT QUIT STOP 

--- a/fluentd-operator/deployments/cr-fluentd-elastic-example.yaml
+++ b/fluentd-operator/deployments/cr-fluentd-elastic-example.yaml
@@ -1,0 +1,15 @@
+apiVersion: logging.pf9.io/v1alpha1
+kind: Output
+metadata:
+  name: elastic-obj 
+spec:
+  type: elasticsearch
+  params:
+    - name: url
+      value: http://%CHANGE_SVC%.%CHANGE_NAMESPACE%.svc.cluster.local:9200 
+    - name: user
+      value: %CHANGE_USER%
+    - name: password
+      value: %CHANGE_PASS%
+    - name: index_name
+      value: demo-test

--- a/fluentd-operator/deployments/elasticsearch.yaml
+++ b/fluentd-operator/deployments/elasticsearch.yaml
@@ -1,0 +1,19 @@
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: app-elasticsearch 
+  namespace: logging
+spec:
+  version: 7.7.1
+  http:
+    tls:
+      selfSignedCertificate:
+        disabled: true
+  nodeSets:
+  - name: default
+    count: 1
+    config:
+      node.master: true
+      node.data: true
+      node.ingest: true
+      node.store.allow_mmap: false

--- a/fluentd-operator/deployments/kibana.yaml
+++ b/fluentd-operator/deployments/kibana.yaml
@@ -1,0 +1,10 @@
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: app-kibana 
+  namespace: logging 
+spec:
+  version: 7.7.1
+  count: 1
+  elasticsearchRef:
+    name: app-elasticsearch 


### PR DESCRIPTION
This script allows you to connect to the cluster and perform the following tasks

- Deploy ECK(Elastic Cloud on Kubernetes) stack with elasticsearch and kibana
- Configure fluentd-operator to push logs to elasticsearch
- Read secrets and make required configurations in fluentd-operator

## PRE-REQUISITES:
- Fluentd-operator should already be deployed on the cluster
- Cluster should be accessible using kubectl commands(set `KUBECONFIG`)